### PR TITLE
Update to module latest version to support darwin_arm64

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ provider "aws" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.64.0"
+  version = "3.14.0"
 
   cidr = var.vpc_cidr_block
 


### PR DESCRIPTION
- Updating to more recent version of `vpc-module`
- Adds support for those running ARM64