### PR TITLE
Add vpc_id output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,8 @@ output "private_subnet_ids" {
   description = "Private subnet IDs"
   value       = module.vpc.private_subnets
 }
+
+output "vpc_id" {
+  description = "ID of project VPC"
+  value       = module.vpc.vpc_id
+}


### PR DESCRIPTION
When trying to perform the cleanup step within this tutorial https://developer.hashicorp.com/terraform/tutorials/certification-associate-tutorials/data-sources for the vpc, there is an error that vpc_id is not an attribute and fails the destroying of deployed services.

Thus, this output rectifies the issue.